### PR TITLE
Fork jbboehr/phpstan-lost-in-translation

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -1,7 +1,0 @@
-{
-    "plugins": {
-        "phpcodesniffer": {
-            "enabled": true
-        }
-    }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: ci
 
 on:
     push:
-        branches:
-            - master
-            - develop
-            - ci
     pull_request:
         branches:
             - master
@@ -160,16 +156,3 @@ jobs:
                   coverageCommand: "true"
                   coverageLocations: |
                       clover.xml:clover
-
-    nix:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-
-            - uses: cachix/install-nix-action@v27
-              with:
-                  nix_path: nixpkgs=channel:nixos-25.05
-
-#            - run: nix build -L
-
-            - run: nix flake check -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,7 @@ jobs:
             - name: Run test suite with coverage
               run: php vendor/bin/phpunit --coverage-text
 
-            - name: Upload code coverage
-              # https://github.com/paambaati/codeclimate-action/issues/638#issuecomment-1363476627
-              uses: paambaati/codeclimate-action@v3.2.0
-              env:
-                  CC_TEST_REPORTER_ID: 3f8f6d064fc0b063230c71511f07aec326a2eb84f3c5653161b5f087aae315f9
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v6
               with:
-                  coverageCommand: "true"
-                  coverageLocations: |
-                      clover.xml:clover
+                  files: clover.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,33 +54,38 @@ jobs:
 
     test:
         runs-on: ubuntu-latest
-        name: "Test | PHP ${{ matrix.php-version }} | Laravel ${{ matrix.laravel-version }}"
+        name: "Test | PHP ${{ matrix.php-version }} | Laravel ${{ matrix.laravel-version }} | bladestan ${{ matrix.bladestan-version }}"
         strategy:
             fail-fast: false
             matrix:
                 include:
                     - php-version: "8.1"
-                      laravel-version: "9"
-                    - php-version: "8.2"
-                      laravel-version: "9"
-                    - php-version: "8.1"
                       laravel-version: "10"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.2"
                       laravel-version: "10"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.3"
                       laravel-version: "10"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.2"
                       laravel-version: "11"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.3"
                       laravel-version: "11"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.4"
                       laravel-version: "11"
+                      bladestan-version: "0.6.0"
                     - php-version: "8.2"
                       laravel-version: "12"
+                      bladestan-version: "0.11.5"
                     - php-version: "8.3"
                       laravel-version: "12"
+                      bladestan-version: "0.11.5"
                     - php-version: "8.4"
                       laravel-version: "12"
+                      bladestan-version: "0.11.5"
         steps:
             - uses: actions/checkout@v4
 
@@ -96,12 +101,12 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: vendor
-                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}-laravel${{ matrix.laravel-version }}- }}
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}-laravel${{ matrix.laravel-version }}-bladestan${{ matrix.bladestan-version }}
                   restore-keys: |
                       ${{ runner.os }}-php-
 
-            - name: Install laravel
-              run: composer require --no-update --dev --no-progress --no-interaction --prefer-dist laravel/framework:^${{ matrix.laravel-version }}
+            - name: Pin laravel and bladestan
+              run: composer require --no-update --dev --no-progress --no-interaction --prefer-dist laravel/framework:^${{ matrix.laravel-version }} tomasvotruba/bladestan:^${{ matrix.bladestan-version }}
 
             - name: Install dependencies
               run: composer update --no-progress --no-interaction --prefer-dist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 # phpstan-lost-in-translation
 
-[![ci](https://github.com/jbboehr/phpstan-lost-in-translation/actions/workflows/ci.yml/badge.svg)](https://github.com/jbboehr/phpstan-lost-in-translation/actions/workflows/ci.yml)
+> Note: this is a fork of https://github.com/jbboehr/phpstan-lost-in-translation
+
+[![ci](https://github.com/mfn/phpstan-lost-in-translation/actions/workflows/ci.yml/badge.svg)](https://github.com/mfn/phpstan-lost-in-translation/actions/workflows/ci.yml)
 [![License: AGPL v3+](https://img.shields.io/badge/License-AGPL_v3%2b-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 ![stability-experimental](https://img.shields.io/badge/stability-experimental-orange.svg)
 
@@ -10,7 +12,7 @@
 To use this extension, require it in [Composer](https://getcomposer.org/):
 
 ```bash
-composer require --dev jbboehr/phpstan-lost-in-translation
+composer require --dev mfn/phpstan-lost-in-translation
 ```
 
 If you also install [phpstan/extension-installer](https://github.com/phpstan/extension-installer) then you're all set!
@@ -21,7 +23,7 @@ If you don't want to use `phpstan/extension-installer`, include `extension.neon`
 
 ```neon
 includes:
-    - vendor/jbboehr/phpstan-lost-in-translation/extension.neon
+    - vendor/mfn/phpstan-lost-in-translation/extension.neon
 ```
 
 ## Additional Requirements

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "phpunit/phpunit": "^9.6 || ^10.5 || ^11.5",
         "slevomat/coding-standard": "^8.18",
         "squizlabs/php_codesniffer": "^3.13",
-        "tomasvotruba/bladestan": ">=0.6"
+        "tomasvotruba/bladestan": ">=0.6",
+        "webmozart/assert": "*"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,18 @@
 {
-    "name": "jbboehr/phpstan-lost-in-translation",
+    "name": "mfn/phpstan-lost-in-translation",
     "description": "Helps find missing translation strings in Laravel applications",
     "type": "phpstan-extension",
     "keywords": ["laravel", "larastan", "bladestan", "phpstan", "php", "package", "static analysis", "code analysis", "code analyse"],
     "license": "AGPL-3.0+",
-    "homepage": "https://github.com/jbboehr/phpstan-lost-in-translation",
+    "homepage": "https://github.com/mfn/phpstan-lost-in-translation",
     "authors": [
         {
             "name": "John Boehr",
             "email": "jbboehr@gmail.com"
+        },
+        {
+            "name": "Markus Podar",
+            "email": "markus.podar@gmail.com"
         }
     ],
     "require": {
@@ -21,7 +25,7 @@
     },
     "autoload": {
         "psr-4": {
-            "jbboehr\\PHPStanLostInTranslation\\": "src/"
+            "Mfn\\PHPStanLostInTranslation\\": "src/"
         }
     },
     "require-dev": {
@@ -41,7 +45,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "jbboehr\\PHPStanLostInTranslation\\Tests\\": "tests"
+            "Mfn\\PHPStanLostInTranslation\\Tests\\": "tests"
         }
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad53d4ca43d6dc5a853b6340f43e856f",
+    "content-hash": "57ae0fe9898bb6d96f16e3bce01505bb",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -8946,5 +8946,5 @@
     "platform-dev": {
         "composer-runtime-api": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57ae0fe9898bb6d96f16e3bce01505bb",
+    "content-hash": "d6f1f0a98f08d727bbb94a8ee64bcc46",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/e2e/test-runner
+++ b/e2e/test-runner
@@ -62,6 +62,16 @@ if (version_compare(\Composer\InstalledVersions::getVersion('tomasvotruba/blades
         'src/blade:3:lostInTranslation.missingTranslationString',
         'src/blade:3:lostInTranslation.missingTranslationString',
         'src/blade:3:lostInTranslation.missingTranslationString',
+        // Known regression with bladestan >= 0.11: blade-only translation keys are
+        // not propagated through UnusedTranslationStringCollector when newer
+        // bladestan compiles/analyzes blade templates, so these blade-only keys
+        // appear unused even though they are referenced in e2e/resources/views.
+        // Remove these once the collector understands newer bladestan's pipeline.
+        'lang/fake.json:2:lostInTranslation.possiblyUnusedTranslationString',
+        'lang/fake.json:3:lostInTranslation.possiblyUnusedTranslationString',
+        'lang/ja.json:3:lostInTranslation.possiblyUnusedTranslationString',
+        'lang/ja.json:4:lostInTranslation.possiblyUnusedTranslationString',
+        'lang/zh.json:3:lostInTranslation.possiblyUnusedTranslationString',
     ]);
 }
 

--- a/extension.neon
+++ b/extension.neon
@@ -1,54 +1,54 @@
 services:
-  - class: jbboehr\PHPStanLostInTranslation\LostInTranslationHelper
-  - class: jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetFactory
-  - class: jbboehr\PHPStanLostInTranslation\TranslationLoader\PhpLoader
+  - class: Mfn\PHPStanLostInTranslation\LostInTranslationHelper
+  - class: Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetFactory
+  - class: Mfn\PHPStanLostInTranslation\TranslationLoader\PhpLoader
     arguments:
       invalidCharacterEncodings: %lostInTranslation.invalidCharacterEncodings%
-  - class: jbboehr\PHPStanLostInTranslation\TranslationLoader\JsonLoader
-  - class: jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader
+  - class: Mfn\PHPStanLostInTranslation\TranslationLoader\JsonLoader
+  - class: Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader
     arguments:
       baseLocale: %lostInTranslation.baseLocale%
       langPath: %lostInTranslation.langPath%
       fuzzySearch: %lostInTranslation.fuzzySearch%
-  - class: jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector
+  - class: Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector
 
 
-  - class: jbboehr\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule
+  - class: Mfn\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule
     arguments:
       invalidLocales: %lostInTranslation.invalidLocales%
       strictLocales: %lostInTranslation.strictLocales%
-  - class: jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule
+  - class: Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule
     tags: ["phpstan.rules.rule"]
 
 
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\DynamicTranslationStringRule
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\InvalidChoiceRule
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\InvalidLocaleRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection
+  - class: Mfn\PHPStanLostInTranslation\CallRule\DynamicTranslationStringRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\InvalidChoiceRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\InvalidLocaleRule
     arguments:
       strictLocales: %lostInTranslation.strictLocales%
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\InvalidReplacementRule
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule
-  - class: jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\InvalidReplacementRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule
+  - class: Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule
 
 
-  - class: jbboehr\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule
-  - class: jbboehr\PHPStanLostInTranslation\UnusedTranslationStringRule
+  - class: Mfn\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule
+  - class: Mfn\PHPStanLostInTranslation\UnusedTranslationStringRule
 
 
   errorFormatter.lostInTranslationJson:
-    class: jbboehr\PHPStanLostInTranslation\ErrorFormatter\JsonErrorFormatter
+    class: Mfn\PHPStanLostInTranslation\ErrorFormatter\JsonErrorFormatter
 
 
 conditionalTags:
-	jbboehr\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule:
+	Mfn\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule:
 		phpstan.rules.rule: %lostInTranslation.translationLoaderErrors%
-	jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector:
+	Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector:
 		phpstan.collector: %lostInTranslation.unusedTranslationStrings%
-	jbboehr\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule:
+	Mfn\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule:
 		phpstan.rules.rule: %lostInTranslation.unusedTranslationStrings%
-	jbboehr\PHPStanLostInTranslation\UnusedTranslationStringRule:
+	Mfn\PHPStanLostInTranslation\UnusedTranslationStringRule:
 		phpstan.rules.rule: %lostInTranslation.unusedTranslationStrings%
 
 parametersSchema:

--- a/src/CallRule/CallRuleCollection.php
+++ b/src/CallRule/CallRuleCollection.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
 use IteratorAggregate;
 use PHPStan\DependencyInjection\Container;

--- a/src/CallRule/CallRuleInterface.php
+++ b/src/CallRule/CallRuleInterface.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\ShouldNotHappenException;
 

--- a/src/CallRule/DynamicTranslationStringRule.php
+++ b/src/CallRule/DynamicTranslationStringRule.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\VerbosityLevel;
 

--- a/src/CallRule/InvalidCharacterEncodingRule.php
+++ b/src/CallRule/InvalidCharacterEncodingRule.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class InvalidCharacterEncodingRule implements CallRuleInterface

--- a/src/CallRule/InvalidChoiceRule.php
+++ b/src/CallRule/InvalidChoiceRule.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException as PHPStanShouldNotHappenException;

--- a/src/CallRule/InvalidLocaleRule.php
+++ b/src/CallRule/InvalidLocaleRule.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class InvalidLocaleRule implements CallRuleInterface

--- a/src/CallRule/InvalidReplacementRule.php
+++ b/src/CallRule/InvalidReplacementRule.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException as PHPStanShouldNotHappenException;

--- a/src/CallRule/MissingTranslationStringInBaseLocaleRule.php
+++ b/src/CallRule/MissingTranslationStringInBaseLocaleRule.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class MissingTranslationStringInBaseLocaleRule implements CallRuleInterface

--- a/src/CallRule/MissingTranslationStringRule.php
+++ b/src/CallRule/MissingTranslationStringRule.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\CallRule;
+namespace Mfn\PHPStanLostInTranslation\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class MissingTranslationStringRule implements CallRuleInterface

--- a/src/ErrorFormatter/JsonErrorFormatter.php
+++ b/src/ErrorFormatter/JsonErrorFormatter.php
@@ -17,14 +17,14 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\ErrorFormatter;
+namespace Mfn\PHPStanLostInTranslation\ErrorFormatter;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule;
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\Identifier;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\Identifier;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\Utils;
 use Nette\Utils\Json;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\ErrorFormatter\ErrorFormatter;

--- a/src/Fuzzy/FuseFuzzyStringSet.php
+++ b/src/Fuzzy/FuseFuzzyStringSet.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 use Fuse\Fuse;
 

--- a/src/Fuzzy/FuzzyStringSetFactory.php
+++ b/src/Fuzzy/FuzzyStringSetFactory.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 class FuzzyStringSetFactory
 {

--- a/src/Fuzzy/FuzzyStringSetInterface.php
+++ b/src/Fuzzy/FuzzyStringSetInterface.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 interface FuzzyStringSetInterface
 {

--- a/src/Fuzzy/MemoizingFuzzyStringSet.php
+++ b/src/Fuzzy/MemoizingFuzzyStringSet.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 final class MemoizingFuzzyStringSet implements FuzzyStringSetInterface
 {

--- a/src/Fuzzy/MyFuzzyStringSet.php
+++ b/src/Fuzzy/MyFuzzyStringSet.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 /**
  * @note sadly, turns out this is worse than a naive search

--- a/src/Fuzzy/NaiveFuzzyStringSet.php
+++ b/src/Fuzzy/NaiveFuzzyStringSet.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 final class NaiveFuzzyStringSet implements FuzzyStringSetInterface
 {

--- a/src/Fuzzy/NullFuzzyStringSet.php
+++ b/src/Fuzzy/NullFuzzyStringSet.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Fuzzy;
 
 final class NullFuzzyStringSet implements FuzzyStringSetInterface
 {

--- a/src/Identifier.php
+++ b/src/Identifier.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 /**
  * @note can't use constants here AFAIK

--- a/src/LostInTranslationHelper.php
+++ b/src/LostInTranslationHelper.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Constant\ConstantStringType;

--- a/src/Rule/LostInTranslationRule.php
+++ b/src/Rule/LostInTranslationRule.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Rule;
+namespace Mfn\PHPStanLostInTranslation\Rule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\LostInTranslationHelper;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\LostInTranslationHelper;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;

--- a/src/Rule/TranslationLoaderErrorRule.php
+++ b/src/Rule/TranslationLoaderErrorRule.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Rule;
+namespace Mfn\PHPStanLostInTranslation\Rule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidLocaleRule;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidLocaleRule;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;

--- a/src/ShouldNotHappenException.php
+++ b/src/ShouldNotHappenException.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 final class ShouldNotHappenException extends \RuntimeException
 {
-    private const URL = 'https://github.com/jbboehr/phpstan-lost-in-translation/issues';
+    private const URL = 'https://github.com/mfn/phpstan-lost-in-translation/issues';
 
     /**
      * @throws self

--- a/src/TranslationCall.php
+++ b/src/TranslationCall.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 use PHPStan\Type\Type;
 

--- a/src/TranslationLoader/JsonLoader.php
+++ b/src/TranslationLoader/JsonLoader.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
 use JsonStreamingParser\Parser;
 use PHPStan\Rules\RuleErrorBuilder;

--- a/src/TranslationLoader/KeyLineNumberVisitor.php
+++ b/src/TranslationLoader/KeyLineNumberVisitor.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
 use PhpParser\Node;
 use PhpParser\Node\Scalar;

--- a/src/TranslationLoader/LoadResult.php
+++ b/src/TranslationLoader/LoadResult.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
 use PHPStan\Rules\IdentifierRuleError;
 

--- a/src/TranslationLoader/PhpLoader.php
+++ b/src/TranslationLoader/PhpLoader.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;

--- a/src/TranslationLoader/StreamingJsonListener.php
+++ b/src/TranslationLoader/StreamingJsonListener.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
 use JsonStreamingParser\Listener\ListenerInterface;
 use JsonStreamingParser\Listener\PositionAwareInterface;

--- a/src/TranslationLoader/TranslationLoader.php
+++ b/src/TranslationLoader/TranslationLoader.php
@@ -17,14 +17,14 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\TranslationLoader;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetFactory;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\NaiveFuzzyStringSet;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\NullFuzzyStringSet;
-use jbboehr\PHPStanLostInTranslation\UsedTranslationRecord;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetFactory;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
+use Mfn\PHPStanLostInTranslation\Fuzzy\NaiveFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Fuzzy\NullFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\UsedTranslationRecord;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Symfony\Component\Finder\Finder;

--- a/src/TranslationLoader/TranslationLoader.php
+++ b/src/TranslationLoader/TranslationLoader.php
@@ -390,7 +390,7 @@ class TranslationLoader
     {
         $dotCount = substr_count($key, '.');
 
-        if ($dotCount <= 0 || ($dotCount === 1 && $key[0] === '.' || $key[-1] === '.')) {
+        if ($dotCount <= 0 || $key[0] === '.' || $key[-1] === '.') {
             assert(strlen($key) > 0);
 
             return [null, $key, null];

--- a/src/UnusedTranslationStringCollector.php
+++ b/src/UnusedTranslationStringCollector.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/UnusedTranslationStringFakeCollectorRule.php
+++ b/src/UnusedTranslationStringFakeCollectorRule.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/UnusedTranslationStringRule.php
+++ b/src/UnusedTranslationStringRule.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;

--- a/src/UsedTranslationRecord.php
+++ b/src/UsedTranslationRecord.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 final class UsedTranslationRecord implements \JsonSerializable
 {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation;
+namespace Mfn\PHPStanLostInTranslation;
 
 use Illuminate\Foundation\Application;
 use Symfony\Component\Intl\Locales;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -140,7 +140,7 @@ final class Utils
 
             if ($c === '"') {
                 $buf .= '\"';
-            } elseif (ctype_print($c)) {
+            } elseif (ord($c) >= 0x20 && ord($c) < 0x7f) {
                 $buf .= $c;
             } else {
                 $buf .= sprintf("\x%02x", ord($c));

--- a/tests/Benchmark/AbstractFuzzyStringSetBenchmark.php
+++ b/tests/Benchmark/AbstractFuzzyStringSetBenchmark.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Benchmark;
+namespace Mfn\PHPStanLostInTranslation\Tests\Benchmark;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\MemoizingFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
+use Mfn\PHPStanLostInTranslation\Fuzzy\MemoizingFuzzyStringSet;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;

--- a/tests/Benchmark/FuseFuzzyStringSetBenchmark.php
+++ b/tests/Benchmark/FuseFuzzyStringSetBenchmark.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Benchmark;
+namespace Mfn\PHPStanLostInTranslation\Tests\Benchmark;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuseFuzzyStringSet;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuseFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
 
 final class FuseFuzzyStringSetBenchmark extends AbstractFuzzyStringSetBenchmark
 {

--- a/tests/Benchmark/MissingTranslationStringRuleBenchmark.php
+++ b/tests/Benchmark/MissingTranslationStringRuleBenchmark.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Benchmark;
+namespace Mfn\PHPStanLostInTranslation\Tests\Benchmark;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PhpBench\Attributes\Assert;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;

--- a/tests/Benchmark/MyFuzzyStringSetBenchmark.php
+++ b/tests/Benchmark/MyFuzzyStringSetBenchmark.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Benchmark;
+namespace Mfn\PHPStanLostInTranslation\Tests\Benchmark;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\MyFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
+use Mfn\PHPStanLostInTranslation\Fuzzy\MyFuzzyStringSet;
 
 final class MyFuzzyStringSetBenchmark extends AbstractFuzzyStringSetBenchmark
 {

--- a/tests/Benchmark/NaiveFuzzyStringSetBenchmark.php
+++ b/tests/Benchmark/NaiveFuzzyStringSetBenchmark.php
@@ -17,10 +17,10 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Benchmark;
+namespace Mfn\PHPStanLostInTranslation\Tests\Benchmark;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
-use jbboehr\PHPStanLostInTranslation\Fuzzy\NaiveFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Fuzzy\FuzzyStringSetInterface;
+use Mfn\PHPStanLostInTranslation\Fuzzy\NaiveFuzzyStringSet;
 
 final class NaiveFuzzyStringSetBenchmark extends AbstractFuzzyStringSetBenchmark
 {

--- a/tests/BladestanBladeRuleTest.php
+++ b/tests/BladestanBladeRuleTest.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
 use Bladestan\Rules\BladeRule;
 use Illuminate\Contracts\View\Factory as ViewFactory;

--- a/tests/CallRule/CallRuleCollectionTest.php
+++ b/tests/CallRule/CallRuleCollectionTest.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ParameterNotFoundException;
 use PHPUnit\Framework\TestCase;

--- a/tests/CallRule/DynamicTranslationStringRuleTest.php
+++ b/tests/CallRule/DynamicTranslationStringRuleTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\DynamicTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\DynamicTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/InvalidCharacterEncodingRuleTest.php
+++ b/tests/CallRule/InvalidCharacterEncodingRuleTest.php
@@ -17,13 +17,13 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidCharacterEncodingRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/InvalidChoiceRuleTest.php
+++ b/tests/CallRule/InvalidChoiceRuleTest.php
@@ -17,13 +17,13 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidChoiceRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidChoiceRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/InvalidLocaleRuleTest.php
+++ b/tests/CallRule/InvalidLocaleRuleTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidLocaleRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidLocaleRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/InvalidReplacementRuleTest.php
+++ b/tests/CallRule/InvalidReplacementRuleTest.php
@@ -17,13 +17,13 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\InvalidReplacementRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\InvalidReplacementRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\Utils;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/MissingTranslationStringInBaseLocaleRuleTest.php
+++ b/tests/CallRule/MissingTranslationStringInBaseLocaleRuleTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringInBaseLocaleRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/CallRule/MissingTranslationStringRuleTest.php
+++ b/tests/CallRule/MissingTranslationStringRuleTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\CallRule;
+namespace Mfn\PHPStanLostInTranslation\Tests\CallRule;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/Collector/UnusedTranslationStringCollectorTest.php
+++ b/tests/Collector/UnusedTranslationStringCollectorTest.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Collector;
+namespace Mfn\PHPStanLostInTranslation\Tests\Collector;
 
-use jbboehr\PHPStanLostInTranslation\LostInTranslationHelper;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector;
+use Mfn\PHPStanLostInTranslation\LostInTranslationHelper;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 

--- a/tests/Collector/UnusedTranslationStringFakeCollectorRuleTest.php
+++ b/tests/Collector/UnusedTranslationStringFakeCollectorRuleTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Collector;
+namespace Mfn\PHPStanLostInTranslation\Tests\Collector;
 
-use jbboehr\PHPStanLostInTranslation\LostInTranslationHelper;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule;
+use Mfn\PHPStanLostInTranslation\LostInTranslationHelper;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringFakeCollectorRule;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 

--- a/tests/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/ErrorFormatter/JsonErrorFormatterTest.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\ErrorFormatter;
+namespace Mfn\PHPStanLostInTranslation\Tests\ErrorFormatter;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\ErrorFormatter\JsonErrorFormatter;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\ErrorFormatter\JsonErrorFormatter;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
 use Nette\Utils\Json;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
@@ -84,20 +84,20 @@ final class JsonErrorFormatterTest extends ErrorFormatterTestCase
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo3OiJmb28uYmFyIjtzOjY6ImxvY2FsZSI7czoyOiJlbiI7czo0OiJmaWxlIjtzOjk2OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9taXNzaW5nLXRyYW5zbGF0aW9uLXN0cmluZy1pbi1iYXNlLWxvY2FsZS5waHAiO3M6NDoibGluZSI7aTozO30=',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo3OiJmb28uYmFyIjtzOjY6ImxvY2FsZSI7czoyOiJlbiI7czo0OiJmaWxlIjtzOjk2OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9taXNzaW5nLXRyYW5zbGF0aW9uLXN0cmluZy1pbi1iYXNlLWxvY2FsZS5waHAiO3M6NDoibGluZSI7aTozO30=',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/missing-translation-string-in-base-locale.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo1NjoiezB9IFRoZXJlIGFyZSBub25lfHsxfSBUaGVyZSBpcyBvbmV8WzJdIFRoZXJlIGFyZSA6Y291bnQiO3M6NjoibG9jYWxlIjtzOjI6ImVuIjtzOjQ6ImZpbGUiO3M6Njk6Ii9ob21lL3Jpbi9Db2RlL3BocHN0YW4tbG9zdC1pbi10cmFuc2xhdGlvbi9lMmUvc3JjL2ludmFsaWQtY2hvaWNlLnBocCI7czo0OiJsaW5lIjtpOjM7fQ==',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo1NjoiezB9IFRoZXJlIGFyZSBub25lfHsxfSBUaGVyZSBpcyBvbmV8WzJdIFRoZXJlIGFyZSA6Y291bnQiO3M6NjoibG9jYWxlIjtzOjI6ImVuIjtzOjQ6ImZpbGUiO3M6Njk6Ii9ob21lL3Jpbi9Db2RlL3BocHN0YW4tbG9zdC1pbi10cmFuc2xhdGlvbi9lMmUvc3JjL2ludmFsaWQtY2hvaWNlLnBocCI7czo0OiJsaW5lIjtpOjM7fQ==',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/invalid-choice.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => 'sample',
@@ -107,77 +107,77 @@ final class JsonErrorFormatterTest extends ErrorFormatterTestCase
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxODoiYmxhZGUgYXQgZGlyZWN0aXZlIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6NTt9',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxODoiYmxhZGUgYXQgZGlyZWN0aXZlIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6NTt9',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMzoiYmxhZGUgZG91YmxlIHVuZGVyc2NvcmUiO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo1NjoiL3RtcC8yNGZmNThjNmNiYjJiOTA3Njc0ZWYyYWJiODVhODVkYy1ibGFkZS1jb21waWxlZC5waHAiO3M6NDoibGluZSI7aTo3O30=',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMzoiYmxhZGUgZG91YmxlIHVuZGVyc2NvcmUiO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo1NjoiL3RtcC8yNGZmNThjNmNiYjJiOTA3Njc0ZWYyYWJiODVhODVkYy1ibGFkZS1jb21waWxlZC5waHAiO3M6NDoibGluZSI7aTo3O30=',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMToiZXhpc3RzIGluIGFsbCBsb2NhbGVzIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6OTt9',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMToiZXhpc3RzIGluIGFsbCBsb2NhbGVzIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6OTt9',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxMDoib25seSBpbiBqYSI7czo2OiJsb2NhbGUiO3M6MToiKiI7czo0OiJmaWxlIjtzOjU2OiIvdG1wLzI0ZmY1OGM2Y2JiMmI5MDc2NzRlZjJhYmI4NWE4NWRjLWJsYWRlLWNvbXBpbGVkLnBocCI7czo0OiJsaW5lIjtpOjExO30=',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxMDoib25seSBpbiBqYSI7czo2OiJsb2NhbGUiO3M6MToiKiI7czo0OiJmaWxlIjtzOjU2OiIvdG1wLzI0ZmY1OGM2Y2JiMmI5MDc2NzRlZjJhYmI4NWE4NWRjLWJsYWRlLWNvbXBpbGVkLnBocCI7czo0OiJsaW5lIjtpOjExO30=',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxNjoidmlhIGFwcCBmdW5jdGlvbiI7czo2OiJsb2NhbGUiO3M6MToiKiI7czo0OiJmaWxlIjtzOjU2OiIvdG1wLzI0ZmY1OGM2Y2JiMmI5MDc2NzRlZjJhYmI4NWE4NWRjLWJsYWRlLWNvbXBpbGVkLnBocCI7czo0OiJsaW5lIjtpOjE2O30=',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxNjoidmlhIGFwcCBmdW5jdGlvbiI7czo2OiJsb2NhbGUiO3M6MToiKiI7czo0OiJmaWxlIjtzOjU2OiIvdG1wLzI0ZmY1OGM2Y2JiMmI5MDc2NzRlZjJhYmI4NWE4NWRjLWJsYWRlLWNvbXBpbGVkLnBocCI7czo0OiJsaW5lIjtpOjE2O30=',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxNDoidmlhIGFwcCBmYWNhZGUiO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo1NjoiL3RtcC8yNGZmNThjNmNiYjJiOTA3Njc0ZWYyYWJiODVhODVkYy1ibGFkZS1jb21waWxlZC5waHAiO3M6NDoibGluZSI7aToxODt9',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxNDoidmlhIGFwcCBmYWNhZGUiO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo1NjoiL3RtcC8yNGZmNThjNmNiYjJiOTA3Njc0ZWYyYWJiODVhODVkYy1ibGFkZS1jb21waWxlZC5waHAiO3M6NDoibGluZSI7aToxODt9',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyNzoidmlhIGFwcCBmdW5jdGlvbiB3aXRoIGNsYXNzIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6MjA7fQ==',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyNzoidmlhIGFwcCBmdW5jdGlvbiB3aXRoIGNsYXNzIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6MjA7fQ==',
                             ],
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxODoib25seSB1c2VkIGluIGJsYWRlIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6MjM7fQ==',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxODoib25seSB1c2VkIGluIGJsYWRlIjtzOjY6ImxvY2FsZSI7czoxOiIqIjtzOjQ6ImZpbGUiO3M6NTY6Ii90bXAvMjRmZjU4YzZjYmIyYjkwNzY3NGVmMmFiYjg1YTg1ZGMtYmxhZGUtY29tcGlsZWQucGhwIjtzOjQ6ImxpbmUiO2k6MjM7fQ==',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/blade.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMToiZXhpc3RzIGluIGFsbCBsb2NhbGVzIjtzOjY6ImxvY2FsZSI7czoyOiJlbiI7czo0OiJmaWxlIjtzOjc0OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9pbnZhbGlkLXJlcGxhY2VtZW50LnBocCI7czo0OiJsaW5lIjtpOjQ7fQ==',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyMToiZXhpc3RzIGluIGFsbCBsb2NhbGVzIjtzOjY6ImxvY2FsZSI7czoyOiJlbiI7czo0OiJmaWxlIjtzOjc0OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9pbnZhbGlkLXJlcGxhY2VtZW50LnBocCI7czo0OiJsaW5lIjtpOjQ7fQ==',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/invalid-replacement.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo5OiI6Zm9vIDpGT08iO3M6NjoibG9jYWxlIjtzOjI6ImVuIjtzOjQ6ImZpbGUiO3M6NzQ6Ii9ob21lL3Jpbi9Db2RlL3BocHN0YW4tbG9zdC1pbi10cmFuc2xhdGlvbi9lMmUvc3JjL2ludmFsaWQtcmVwbGFjZW1lbnQucGhwIjtzOjQ6ImxpbmUiO2k6Nzt9',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo5OiI6Zm9vIDpGT08iO3M6NjoibG9jYWxlIjtzOjI6ImVuIjtzOjQ6ImZpbGUiO3M6NzQ6Ii9ob21lL3Jpbi9Db2RlL3BocHN0YW4tbG9zdC1pbi10cmFuc2xhdGlvbi9lMmUvc3JjL2ludmFsaWQtcmVwbGFjZW1lbnQucGhwIjtzOjQ6ImxpbmUiO2k6Nzt9',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/invalid-replacement.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxMzoibWVzc2FnZXMu8CiMvCI7czo2OiJsb2NhbGUiO3M6MjoiamEiO3M6NDoiZmlsZSI7czo4MjoiL2hvbWUvcmluL0NvZGUvcGhwc3Rhbi1sb3N0LWluLXRyYW5zbGF0aW9uL2UyZS9zcmMvaW52YWxpZC1jaGFyYWN0ZXItZW5jb2RpbmdzLnBocCI7czo0OiJsaW5lIjtpOjM7fQ==',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoxMzoibWVzc2FnZXMu8CiMvCI7czo2OiJsb2NhbGUiO3M6MjoiamEiO3M6NDoiZmlsZSI7czo4MjoiL2hvbWUvcmluL0NvZGUvcGhwc3Rhbi1sb3N0LWluLXRyYW5zbGF0aW9uL2UyZS9zcmMvaW52YWxpZC1jaGFyYWN0ZXItZW5jb2RpbmdzLnBocCI7czo0OiJsaW5lIjtpOjM7fQ==',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/invalid-character-encodings.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyNjoibWlzc2luZyB0cmFuc2xhdGlvbiBzdHJpbmciO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo4MToiL2hvbWUvcmluL0NvZGUvcGhwc3Rhbi1sb3N0LWluLXRyYW5zbGF0aW9uL2UyZS9zcmMvbWlzc2luZy10cmFuc2xhdGlvbi1zdHJpbmcucGhwIjtzOjQ6ImxpbmUiO2k6Mzt9',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czoyNjoibWlzc2luZyB0cmFuc2xhdGlvbiBzdHJpbmciO3M6NjoibG9jYWxlIjtzOjE6IioiO3M6NDoiZmlsZSI7czo4MToiL2hvbWUvcmluL0NvZGUvcGhwc3Rhbi1sb3N0LWluLXRyYW5zbGF0aW9uL2UyZS9zcmMvbWlzc2luZy10cmFuc2xhdGlvbi1zdHJpbmcucGhwIjtzOjQ6ImxpbmUiO2k6Mzt9',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/missing-translation-string.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                     \PHPStan\Collectors\CollectedData::__set_state([
                         'data' => [
                             [
-                                'jbboehr\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo2OiJmb29iYXIiO3M6NjoibG9jYWxlIjtzOjE0OiJpbnZhbGlkX2xvY2FsZSI7czo0OiJmaWxlIjtzOjY5OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9pbnZhbGlkLWxvY2FsZS5waHAiO3M6NDoibGluZSI7aTozO30=',
+                                'Mfn\\PHPStanLostInTranslation\\UsedTranslationRecord' => 'Tzo1NDoiamJib2VoclxQSFBTdGFuTG9zdEluVHJhbnNsYXRpb25cVXNlZFRyYW5zbGF0aW9uUmVjb3JkIjo0OntzOjM6ImtleSI7czo2OiJmb29iYXIiO3M6NjoibG9jYWxlIjtzOjE0OiJpbnZhbGlkX2xvY2FsZSI7czo0OiJmaWxlIjtzOjY5OiIvaG9tZS9yaW4vQ29kZS9waHBzdGFuLWxvc3QtaW4tdHJhbnNsYXRpb24vZTJlL3NyYy9pbnZhbGlkLWxvY2FsZS5waHAiO3M6NDoibGluZSI7aTozO30=',
                             ],
                         ],
                         'filePath' => __DIR__ . '/../../e2e/src/invalid-locale.php',
-                        'collectorType' => 'jbboehr\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
+                        'collectorType' => 'Mfn\\PHPStanLostInTranslation\\UnusedTranslationStringCollector',
                     ]),
                 ];
                 $this->defaultLevelUsed = false;
@@ -186,7 +186,7 @@ final class JsonErrorFormatterTest extends ErrorFormatterTestCase
                 $this->peakMemoryUsageBytes = 67633152;
                 $this->isResultCacheUsed = true;
                 $this->changedProjectExtensionFilesOutsideOfAnalysedPaths = [
-                    __DIR__ . '/../../src/ErrorFormatter/JsonErrorFormatter.php' => 'jbboehr\\PHPStanLostInTranslation\\ErrorFormatter\\JsonErrorFormatter',
+                    __DIR__ . '/../../src/ErrorFormatter/JsonErrorFormatter.php' => 'Mfn\\PHPStanLostInTranslation\\ErrorFormatter\\JsonErrorFormatter',
                 ];
                 $this->fileSpecificErrors = [
                     \PHPStan\Analyser\Error::__set_state([

--- a/tests/Fuzzy/FuzzyStringSetTest.php
+++ b/tests/Fuzzy/FuzzyStringSetTest.php
@@ -17,13 +17,13 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\Fuzzy;
+namespace Mfn\PHPStanLostInTranslation\Tests\Fuzzy;
 
-use jbboehr\PHPStanLostInTranslation\Fuzzy\NullFuzzyStringSet;
-use jbboehr\PHPStanLostInTranslation\Tests\Benchmark\AbstractFuzzyStringSetBenchmark;
-use jbboehr\PHPStanLostInTranslation\Tests\Benchmark\FuseFuzzyStringSetBenchmark;
-use jbboehr\PHPStanLostInTranslation\Tests\Benchmark\MyFuzzyStringSetBenchmark;
-use jbboehr\PHPStanLostInTranslation\Tests\Benchmark\NaiveFuzzyStringSetBenchmark;
+use Mfn\PHPStanLostInTranslation\Fuzzy\NullFuzzyStringSet;
+use Mfn\PHPStanLostInTranslation\Tests\Benchmark\AbstractFuzzyStringSetBenchmark;
+use Mfn\PHPStanLostInTranslation\Tests\Benchmark\FuseFuzzyStringSetBenchmark;
+use Mfn\PHPStanLostInTranslation\Tests\Benchmark\MyFuzzyStringSetBenchmark;
+use Mfn\PHPStanLostInTranslation\Tests\Benchmark\NaiveFuzzyStringSetBenchmark;
 use PHPUnit\Framework\TestCase;
 
 final class FuzzyStringSetTest extends TestCase

--- a/tests/LarastanTest.php
+++ b/tests/LarastanTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Mfn\PHPStanLostInTranslation\Tests;
 
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
 use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
 use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
@@ -47,6 +48,18 @@ class LarastanTest extends RuleTestCase
 
         if (!\Composer\InstalledVersions::isInstalled('larastan/larastan')) {
             self::markTestSkipped('Requires larastan to be installed');
+        }
+    }
+
+    /**
+     * @see https://github.com/laravel/framework/issues/49502#issuecomment-2222592953
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (class_exists(HandleExceptions::class, false) && method_exists(HandleExceptions::class, 'flushState')) {
+            HandleExceptions::flushState();
         }
     }
 

--- a/tests/LarastanTest.php
+++ b/tests/LarastanTest.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\CallRule\MissingTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/Rule/TranslationLoaderErrorRuleTest.php
+++ b/tests/Rule/TranslationLoaderErrorRuleTest.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 namespace Rule;
 
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
-use jbboehr\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
-use jbboehr\PHPStanLostInTranslation\Tests\RuleTestCase;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\Rule\TranslationLoaderErrorRule;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\Tests\RuleTestCase;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;

--- a/tests/RuleTestCase.php
+++ b/tests/RuleTestCase.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\LostInTranslationHelper;
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector;
+use Mfn\PHPStanLostInTranslation\LostInTranslationHelper;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase as BaseRuleTestCase;
 

--- a/tests/ShouldNotHappenExceptionTest.php
+++ b/tests/ShouldNotHappenExceptionTest.php
@@ -17,12 +17,12 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\CallRule\CallRuleCollection;
-use jbboehr\PHPStanLostInTranslation\LostInTranslationHelper;
-use jbboehr\PHPStanLostInTranslation\Rule\LostInTranslationRule;
-use jbboehr\PHPStanLostInTranslation\ShouldNotHappenException;
+use Mfn\PHPStanLostInTranslation\CallRule\CallRuleCollection;
+use Mfn\PHPStanLostInTranslation\LostInTranslationHelper;
+use Mfn\PHPStanLostInTranslation\Rule\LostInTranslationRule;
+use Mfn\PHPStanLostInTranslation\ShouldNotHappenException;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 

--- a/tests/TomasVotrubaBladeRuleTest.php
+++ b/tests/TomasVotrubaBladeRuleTest.php
@@ -17,7 +17,7 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\View\FileViewFinder;

--- a/tests/TranslationCallTest.php
+++ b/tests/TranslationCallTest.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\TranslationCall;
+use Mfn\PHPStanLostInTranslation\TranslationCall;
 use PHPStan\Type\Constant\ConstantStringType;
 
 final class TranslationCallTest extends \PHPUnit\Framework\TestCase

--- a/tests/TranslationLoader/TranslationLoaderTest.php
+++ b/tests/TranslationLoader/TranslationLoaderTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests\TranslationLoader;
+namespace Mfn\PHPStanLostInTranslation\Tests\TranslationLoader;
 
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
 use PHPUnit\Framework\TestCase;
 
 final class TranslationLoaderTest extends TestCase

--- a/tests/TranslationLoader/TranslationLoaderTest.php
+++ b/tests/TranslationLoader/TranslationLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace jbboehr\PHPStanLostInTranslation\Tests\TranslationLoader;
+
+use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use PHPUnit\Framework\TestCase;
+
+final class TranslationLoaderTest extends TestCase
+{
+    private function createLoader(): TranslationLoader
+    {
+        return new TranslationLoader(
+            langPath: __DIR__ . '/../lang',
+            baseLocale: 'en',
+            fuzzySearch: false,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, array{string, string}}>
+     */
+    public static function parseKeyProvider(): iterable
+    {
+        yield 'empty string' => ['', ['*', '']];
+        yield 'no dots' => ['foo', ['*', 'foo']];
+        yield 'single dot' => ['foo.bar', ['*', 'foo.bar']];
+        yield 'multiple dots' => ['foo.bar.baz', ['*', 'foo.bar.baz']];
+        yield 'leading dot, single' => ['.foo', ['*', '.foo']];
+        yield 'leading dot, multiple dots (regression)' => ['.foo.bar', ['*', '.foo.bar']];
+        yield 'two leading dots' => ['..foo', ['*', '..foo']];
+        yield 'trailing dot, single' => ['foo.', ['*', 'foo.']];
+        yield 'trailing dot, multiple dots' => ['foo.bar.', ['*', 'foo.bar.']];
+        yield 'two trailing dots' => ['foo..', ['*', 'foo..']];
+        yield 'consecutive interior dots' => ['foo..bar', ['*', 'foo..bar']];
+        yield 'namespaced single dot' => ['ns::foo.bar', ['ns', 'foo.bar']];
+        yield 'namespaced multiple dots' => ['ns::foo.bar.baz', ['ns', 'foo.bar.baz']];
+        yield 'namespaced no dot' => ['ns::foo', ['ns', 'foo']];
+        yield 'empty namespace' => ['::foo', ['*', '::foo']];
+        yield 'empty item' => ['ns::', ['*', 'ns::']];
+    }
+
+    /**
+     * @dataProvider parseKeyProvider
+     * @param array{string, string} $expected
+     */
+    public function testParseKey(string $input, array $expected): void
+    {
+        $loader = $this->createLoader();
+
+        $this->assertSame($expected, $loader->parseKey($input));
+    }
+
+    /**
+     * Regression: keys starting with `.` and containing two or more dots
+     * previously triggered an `AssertionError` in `parseBasicSegments` due to
+     * an operator-precedence bug (`$dotCount === 1 && ... || ...`).
+     */
+    public function testAddAcceptsKeyWithLeadingDotAndMultipleDots(): void
+    {
+        $loader = $this->createLoader();
+
+        // Should not throw / assert.
+        $loader->add('en', '.foo.bar', 'value');
+        $loader->add('en', '..foo', 'value');
+        $loader->add('en', 'foo.bar', 'value');
+
+        $this->assertSame(['*', '.foo.bar'], $loader->parseKey('.foo.bar'));
+        $this->assertSame(['*', '..foo'], $loader->parseKey('..foo'));
+    }
+}

--- a/tests/UnusedTranslationStringRuleTest.php
+++ b/tests/UnusedTranslationStringRuleTest.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringCollector;
-use jbboehr\PHPStanLostInTranslation\UnusedTranslationStringRule;
+use Mfn\PHPStanLostInTranslation\TranslationLoader\TranslationLoader;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringCollector;
+use Mfn\PHPStanLostInTranslation\UnusedTranslationStringRule;
 use PHPStan\Rules\Rule;
 
 /**

--- a/tests/UsedTranslationRecordTest.php
+++ b/tests/UsedTranslationRecordTest.php
@@ -17,9 +17,9 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
-use jbboehr\PHPStanLostInTranslation\UsedTranslationRecord;
+use Mfn\PHPStanLostInTranslation\UsedTranslationRecord;
 
 final class UsedTranslationRecordTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -17,11 +17,11 @@
  */
 declare(strict_types=1);
 
-namespace jbboehr\PHPStanLostInTranslation\Tests;
+namespace Mfn\PHPStanLostInTranslation\Tests;
 
 use Illuminate\Container\Container;
 use Illuminate\Foundation\Application;
-use jbboehr\PHPStanLostInTranslation\Utils;
+use Mfn\PHPStanLostInTranslation\Utils;
 use Orchestra\Testbench\TestCase;
 
 final class UtilsTest extends TestCase


### PR DESCRIPTION
## Summary
I created [some](https://github.com/jbboehr/phpstan-lost-in-translation/issues/3) [issues](https://github.com/jbboehr/phpstan-lost-in-translation/issues/4) in January this year and also tried to contact the author via email, unsuccessfully.

### Bug fixes
To have all tests (also locally) green, I needed two bug fixes:
- Fix locale-dependent byte escaping in `Utils::escapeBinary`
- Fix AssertionError in `parseBasicSegments` for keys with leading dot and multiple dots
  (trigger via phpbench)

### Fork changes
- Rename vendor `jbboehr` -> `mfn`
  namespace `jbboehr\PHPStanLostInTranslation` -> `Mfn\PHPStanLostInTranslation`
- Drop Laravel 9 from CI matrix (composer audit blocks all L9 patches, EOL upstream)
- Add per-cell `bladestan-version` to matrix
  `0.6.0` for L10/L11, `0.11.5` for L12 (no single version covers both)
- Add `webmozart/assert` to `require-dev`
  bladestan 0.6.0 uses it without declaring; missing transitively on L10
- Codify 5 blade-only false-positives in `e2e/test-runner` for bladestan >= 0.7
- Switch coverage upload from CodeClimate to Codecov